### PR TITLE
Fixed multiple table header rows

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -190,7 +190,7 @@ if (typeof jQuery === 'undefined') {
                                        </div></div>';
 
                         // Add toolbar column cells.
-                        $table.find('tr:gt(0)').append('<td style="white-space: nowrap; width: 1%;">' + toolbar + '</td>');
+                        $table.find('tbody>tr').append('<td style="white-space: nowrap; width: 1%;">' + toolbar + '</td>');
                     }
                 }
             }


### PR DESCRIPTION
Now only shows edit/delete buttons for the actual data rows instead of always selecting the second row. This fixes the issue in case there are multiple table header rows.

Related to issue; [#23](https://github.com/markcell/jquery-tabledit/issues/23)