### PR TITLE
prevent binding keyup to ALL elements in document

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -569,7 +569,7 @@ if (typeof jQuery === 'undefined') {
          *
          * @param {object} event
          */
-        $(document).on('keyup', function(event) {
+        $(document).on('keyup', '.tabledit-input', function(event) {
             // Get input element with focus or confirmation button.
             var $input = $table.find('.tabledit-input:visible');
             var $button = $table.find('.tabledit-confirm-button');


### PR DESCRIPTION
Now tabledit binds "keyup" event to ALL elements in document, this change ensures to bind this event only to .tabledit-input