### PR TITLE
do not send request if no data is serialized

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -369,7 +369,13 @@ if (typeof jQuery === 'undefined') {
          */
         function ajax(action)
         {
-            var serialize = $table.find('.tabledit-input').serialize() + '&action=' + action;
+            var serialize = $table.find('.tabledit-input').serialize()
+
+            if (!serialize) {
+                return false;
+            }
+
+            serialize += '&action=' + action;
 
             var result = settings.onAjax(action, serialize);
 


### PR DESCRIPTION
Now there is a problem with the entire document and the keyup event. If you have a < form > in the same document with a tabledit, the "intro" keyup sends an empty xhr to server.

This fixes this issue in some way.