### PR TITLE
Added support for textarea element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2.4 (2016/06/17)
+-------------------
+- Changed the options to allow 'select', 'text', and 'textarea' input, the fourth parameter becomes the number of rows if textarea, straight json for select options
+
 v1.2.3 (2015/04/20)
 -------------------
 - Added 'bower.json' to use this package manager

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jQuery-Tabledit v1.2.3
+# jQuery-Tabledit v1.2.4
 Inline editor for HTML tables compatible with Bootstrap.
 
 

--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -120,26 +120,42 @@ if (typeof jQuery === 'undefined') {
 
                             // Create span element.
                             var span = '<span class="tabledit-span">' + text + '</span>';
-
+                            var input = "";
                             // Check if exists the third parameter of editable array.
-                            if (typeof settings.columns.editable[i][2] !== 'undefined') {
-                                // Create select element.
-                                var input = '<select class="tabledit-input ' + settings.inputClass + '" name="' + settings.columns.editable[i][1] + '" style="display: none;" disabled>';
+                            // switch the third parameter to test for input type default is text
+                            switch(settings.columns.editable[i][2])
+                            {
+                                case "textarea":
+                                    input = '<textarea ';
+                                    //each item in 4th object becomes attributes in select
+                                    $.each(settings.columns.editable[i][3], function(index, value) {
+                                        input += index + '="' + value + '" ';
+                                    });
+                                    input += 'class="tabledit-input ' + settings.inputClass + '" name="' + settings.columns.editable[i][1] + '" style="display: none;" disabled>' + $(this).text()  + '</textarea>';
+                                    
+                                    break;
+                                case "select":
+                                    // Create select element.
+                                    input = '<select class="tabledit-input ' + settings.inputClass + '" name="' + settings.columns.editable[i][1] + '" style="display: none;" disabled>';
 
-                                // Create options for select element.
-                                $.each(jQuery.parseJSON(settings.columns.editable[i][2]), function(index, value) {
-                                    if (text === value) {
-                                        input += '<option value="' + index + '" selected>' + value + '</option>';
-                                    } else {
-                                        input += '<option value="' + index + '">' + value + '</option>';
-                                    }
-                                });
+                                    // Create options for select element.
+                                    $.each(settings.columns.editable[i][3], function(index, value) {
+                                        if (text === value) {
+                                            input += '<option value="' + index + '" selected>' + value + '</option>';
+                                        } else {
+                                            input += '<option value="' + index + '">' + value + '</option>';
+                                        }
+                                    });
 
-                                // Create last piece of select element.
-                                input += '</select>';
-                            } else {
-                                // Create text input element.
-                                var input = '<input class="tabledit-input ' + settings.inputClass + '" type="text" name="' + settings.columns.editable[i][1] + '" value="' + $(this).text() + '" style="display: none;" disabled>';
+                                    // Create last piece of select element.
+                                    input += '</select>';
+                                    
+                                    break;
+                                    
+                                default:
+                                    // Create text input element.
+                                    input = '<input class="tabledit-input ' + settings.inputClass + '" type="text" name="' + settings.columns.editable[i][1] + '" value="' + $(this).text() + '" style="display: none;" disabled>';
+                                    break;
                             }
 
                             // Add elements and class "view" to table cell.


### PR DESCRIPTION
Here's an additional example to use for displaying a textarea.
$("#businessRules").Tabledit({
url: '',
columns: {
identifier: [0, 'ID'],
editable: [
[1, 'Vehicle Type', 'select', {"car": "Car", "truck": "Truck", "van":
"Mini-van", "suv": "Sport Utility Vehicle"}],
[2, 'Description', 'textarea', {rows: 4}]
]
}
});