### PR TITLE
Options didn't compare correctly because of whitespaces

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -128,7 +128,7 @@ if (typeof jQuery === 'undefined') {
 
                                 // Create options for select element.
                                 $.each(jQuery.parseJSON(settings.columns.editable[i][2]), function(index, value) {
-                                    if (text === value) {
+                                    if ($.trim(text) === value) {
                                         input += '<option value="' + index + '" selected>' + value + '</option>';
                                     } else {
                                         input += '<option value="' + index + '">' + value + '</option>';


### PR DESCRIPTION
Dropdown doesn't default to the currently selected option in edit mode, this is because of some whitespaces.
Maybe there's a better way to fix this, but this works for me.

Edit:
ilyaguy's pull request is better, this also fixes this issue: https://github.com/markcell/jquery-tabledit/pull/51